### PR TITLE
main -> master + tp1 link correction in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,29 @@ Finally, chapter 6 makes two openings on two classic linear models, both in mach
 
 In practice, the courses and practicals will be structured in four blocks, each of them containing 1 to 2 hours of course and 2 hours of practicals. All documents linked below are in French.  
 
-- [Block 1](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Bloc1.pdf): In this block, chapter 1 and the 1D linear regression of chapter 2 will be seen in class. The practicals will deal with linear regression, outliers detection and an illustration of the concept of maximum likelihood.
-- [Block 2](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Bloc2.pdf): This block deals with multi-variate linear regression (2nd part of chapter 2), regularisation and cross-validation (chapter 3). These concepts will be manipulated during the practicals.
-- [Block 3](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Bloc3.pdf): This block is more related to statistical aspects of the linear model in data science and focuses on ANOVA (chapter 4). This method will be studied during the practicals, and some time will also be dedicated to further manipulate the concepts of block 2.  
-- [Block 4](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Bloc4.pdf): Extensions of the methods seen before will be seen in this block: Mixed models (chapter 5) and the mathematical construction of logistic regression and the PLS method. The practicals will first deal with PLS but also open questions on the interpretability of the decision rules in machine learning based on the logistic regression example.
+- [Block 1](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Bloc1.pdf): In this block, chapter 1 and the 1D linear regression of chapter 2 will be seen in class. The practicals will deal with linear regression, outliers detection and an illustration of the concept of maximum likelihood.
+- [Block 2](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Bloc2.pdf): This block deals with multi-variate linear regression (2nd part of chapter 2), regularisation and cross-validation (chapter 3). These concepts will be manipulated during the practicals.
+- [Block 3](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Bloc3.pdf): This block is more related to statistical aspects of the linear model in data science and focuses on ANOVA (chapter 4). This method will be studied during the practicals, and some time will also be dedicated to further manipulate the concepts of block 2.  
+- [Block 4](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Bloc4.pdf): Extensions of the methods seen before will be seen in this block: Mixed models (chapter 5) and the mathematical construction of logistic regression and the PLS method. The practicals will first deal with PLS but also open questions on the interpretability of the decision rules in machine learning based on the logistic regression example.
 
 ## Practical sessions
 
 All notebooks in French.  
-[Utilisation de scikit-learn pour la regression lineaire](https://github.com/SupaeroDataScience/stat-ml/blob/main/Exo1_SimpleRegression.ipynb.ipynb)  
-[Régression linéaire multiple et inférence statistique](https://github.com/SupaeroDataScience/stat-ml/blob/master/tp/Exo2_RegressionMultiple.ipynb)  
-[Regression multiple avec régularisaton et validation croisée](https://github.com/SupaeroDataScience/stat-ml/blob/master/tp/Exo3_RegressionMultipleReg.ipynb)  
-[Utilisation de Pandas et sklearn pour l'analyse de données réelles](https://github.com/SupaeroDataScience/stat-ml/blob/master/tp/Exo4_RealDataAnalysis.ipynb)  
-[ANOVA](https://github.com/SupaeroDataScience/stat-ml/blob/master/tp/Exo5_ANOVA.ipynb)  
-[Partial Least Squares](https://github.com/SupaeroDataScience/stat-ml/blob/master/tp/Exo6_PLSregression.ipynb)  
-[Régression logistique et explicabilité](https://github.com/SupaeroDataScience/stat-ml/blob/master/tp/Exo7_RegressionLogistique.ipynb)  
+[Utilisation de scikit-learn pour la regression lineaire](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo1_SimpleRegression.ipynb)  
+[Régression linéaire multiple et inférence statistique](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo2_RegressionMultiple.ipynb)  
+[Regression multiple avec régularisaton et validation croisée](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo3_RegressionMultipleReg.ipynb)  
+[Utilisation de Pandas et sklearn pour l'analyse de données réelles](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo4_RealDataAnalysis.ipynb)  
+[ANOVA](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo5_ANOVA.ipynb)  
+[Partial Least Squares](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo6_PLSregression.ipynb)  
+[Régression logistique et explicabilité](https://github.com/SupaeroDataScience/stat-ml/blob/main/tp/Exo7_RegressionLogistique.ipynb)  
 
 ## Chapters
 
 All documents in French. These chapters correspond to the exact same contents studied during the 4 blocks above.  
-[Chapter 1](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap1.pdf) Introduction  
-[Chapter 2](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap2.pdf) Régression linéaire    
-[Chapter 3](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap3.pdf) Sélection de modèle en régression linéaire multiple  
-[Chapter 4](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap4.pdf) Analyse de variance  
-[Chapter 5](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap5.pdf) Modèle linéaire mixte  
-[Chapter 6](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap6.pdf) Ouvertures  
-[Annexes](https://github.com/SupaeroDataScience/stat-ml/blob/master/cours/Cours_Chap7_Annexe.pdf)
+[Chapter 1](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap1.pdf) Introduction  
+[Chapter 2](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap2.pdf) Régression linéaire    
+[Chapter 3](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap3.pdf) Sélection de modèle en régression linéaire multiple  
+[Chapter 4](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap4.pdf) Analyse de variance  
+[Chapter 5](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap5.pdf) Modèle linéaire mixte  
+[Chapter 6](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap6.pdf) Ouvertures  
+[Annexes](https://github.com/SupaeroDataScience/stat-ml/blob/main/cours/Cours_Chap7_Annexe.pdf)


### PR DESCRIPTION
I saw that the link to the first practical session did not work.

I changed it to point to the right location and also changed all references to master to references to main.
It did work but main branch is called main not master anymore.